### PR TITLE
style: Fix code formatting in link

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ At a high level, a run does four things:
 ## Requirements
 
 - Python 3.10, 3.11, or 3.12
-- `[uv](https://docs.astral.sh/uv/)` for dependency management
+- [`uv`](https://docs.astral.sh/uv/) for dependency management
 - FFmpeg (pulled in via `imageio[ffmpeg]`)
 - **GPU**: strongly recommended. CPU-only runs work with `scsfmlearner` but are slow. The `loger` / `loger_star` backends require CUDA.
 


### PR DESCRIPTION
One line change to turn
<img width="421" height="62" alt="image" src="https://github.com/user-attachments/assets/c8d8bd9d-76a0-4bbb-8ac6-69fd7f4cc93d" />
into
<img width="387" height="75" alt="image" src="https://github.com/user-attachments/assets/65147847-2445-49de-82d1-261311115266" />
