### PR TITLE
fix(deps): pin transformers 4.x for torch 2.4 compatibility

### DIFF
--- a/deepreefmap/segmentation/dinov3_dpt.py
+++ b/deepreefmap/segmentation/dinov3_dpt.py
@@ -29,6 +29,22 @@ class DinoV3DPTWrapper(SegmentationModel):
             raise RuntimeError("Could not load coralscapes_hub_model.py from model repo.")
         mod = importlib.util.module_from_spec(spec)
         spec.loader.exec_module(mod)
+        hub_auto_processor = mod.AutoImageProcessor
+
+        class _FastAutoImageProcessor:
+            @staticmethod
+            def from_pretrained(*args, **kwargs):
+                kwargs.setdefault("use_fast", True)
+                return hub_auto_processor.from_pretrained(*args, **kwargs)
+
+        mod.AutoImageProcessor = _FastAutoImageProcessor
+        hub_load_weights = mod._load_hub_weights
+
+        def _load_hub_weights_compat(path):
+            state = hub_load_weights(path)
+            return {k.replace("encoder.model.", "encoder.", 1): v for k, v in state.items()}
+
+        mod._load_hub_weights = _load_hub_weights_compat
         self._device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
         self._model = mod.Dinov3DPTSegmenter.from_pretrained(root, map_location=self._device).eval()
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,8 +28,11 @@ dependencies = [
   "pyyaml>=6.0.2",
   "scikit-learn>=1.5.0",
   "open3d>=0.18.0",
-  "transformers>=5.8.0",
-  "huggingface_hub>=1.14.0",
+  # transformers 5.x requires torch >=2.7 (string-typed torch.library.custom_op
+  # annotations break torch 2.4's infer_schema), so stay on 4.x while torch is
+  # pinned to 2.4.1 below.
+  "transformers==4.57.3",
+  "huggingface_hub>=0.34.0,<1.0",
   # Keep PyTorch on CUDA 12.1 wheels for the workstation's NVIDIA 535 driver
   # (CUDA 12.2). Newer torch releases may resolve to cu130 and fail CUDA init.
   "torch==2.4.1",

--- a/uv.lock
+++ b/uv.lock
@@ -402,7 +402,7 @@ train = [
 requires-dist = [
     { name = "accelerate", marker = "extra == 'loger'", specifier = ">=0.30.0" },
     { name = "einops", marker = "extra == 'loger'", specifier = ">=0.7.0" },
-    { name = "huggingface-hub", specifier = ">=1.14.0" },
+    { name = "huggingface-hub", specifier = ">=0.34.0,<1.0" },
     { name = "imageio", extras = ["ffmpeg"], specifier = ">=2.37.3" },
     { name = "mypy", marker = "extra == 'dev'", specifier = ">=2.0.0" },
     { name = "natsort", marker = "extra == 'loger'", specifier = ">=8.4.0" },
@@ -421,7 +421,7 @@ requires-dist = [
     { name = "torch", specifier = "==2.4.1" },
     { name = "torchvision", specifier = "==0.19.1" },
     { name = "tqdm", specifier = ">=4.67.3" },
-    { name = "transformers", specifier = ">=5.8.0" },
+    { name = "transformers", specifier = "==4.57.3" },
     { name = "typer", specifier = ">=0.25.1" },
     { name = "viser", specifier = ">=1.0.27" },
     { name = "wandb", marker = "extra == 'train'", specifier = ">=0.20.0" },
@@ -669,22 +669,21 @@ wheels = [
 
 [[package]]
 name = "huggingface-hub"
-version = "1.14.0"
+version = "0.36.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "filelock" },
     { name = "fsspec" },
-    { name = "hf-xet", marker = "platform_machine == 'AMD64' or platform_machine == 'aarch64' or platform_machine == 'amd64' or platform_machine == 'arm64' or platform_machine == 'x86_64'" },
-    { name = "httpx" },
+    { name = "hf-xet", marker = "platform_machine == 'aarch64' or platform_machine == 'amd64' or platform_machine == 'arm64' or platform_machine == 'x86_64'" },
     { name = "packaging" },
     { name = "pyyaml" },
+    { name = "requests" },
     { name = "tqdm" },
-    { name = "typer" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/39/40/43109e943fd718b0ccd0cd61eb4f1c347df22bf81f5874c6f22adf44bcff/huggingface_hub-1.14.0.tar.gz", hash = "sha256:d6d2c9cd6be1d02ae9ec6672d5587d10a427f377db688e82528f426a041622c2", size = 782365, upload-time = "2026-05-06T14:14:34.278Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/7c/b7/8cb61d2eece5fb05a83271da168186721c450eb74e3c31f7ef3169fa475b/huggingface_hub-0.36.2.tar.gz", hash = "sha256:1934304d2fb224f8afa3b87007d58501acfda9215b334eed53072dd5e815ff7a", size = 649782, upload-time = "2026-02-06T09:24:13.098Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/89/a5/33b49ba7bea7c41bb37f74ec0f8beea0831e052330196633fe2c77516ea6/huggingface_hub-1.14.0-py3-none-any.whl", hash = "sha256:efe075535c62e130b30e836b138e13785f6f043d1f0539e0a39aa411a99e90b8", size = 661479, upload-time = "2026-05-06T14:14:32.029Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/af/48ac8483240de756d2438c380746e7130d1c6f75802ef22f3c6d49982787/huggingface_hub-0.36.2-py3-none-any.whl", hash = "sha256:48f0c8eac16145dfce371e9d2d7772854a4f591bcb56c9cf548accf531d54270", size = 566395, upload-time = "2026-02-06T09:24:11.133Z" },
 ]
 
 [[package]]
@@ -2720,23 +2719,24 @@ wheels = [
 
 [[package]]
 name = "transformers"
-version = "5.8.0"
+version = "4.57.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
+    { name = "filelock" },
     { name = "huggingface-hub" },
     { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
     { name = "numpy", version = "2.4.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
     { name = "packaging" },
     { name = "pyyaml" },
     { name = "regex" },
+    { name = "requests" },
     { name = "safetensors" },
     { name = "tokenizers" },
     { name = "tqdm" },
-    { name = "typer" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/f2/36/390075693b76d4fb4a2bea360fb6080347763bd1f1147c49ed0ed938778c/transformers-5.8.0.tar.gz", hash = "sha256:6cc9a1f0291d16b1c1b735bad775e78ebefff7722701d4e28f98aaaa2bd6fb91", size = 8528141, upload-time = "2026-05-05T16:50:04.778Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/dd/70/d42a739e8dfde3d92bb2fff5819cbf331fe9657323221e79415cd5eb65ee/transformers-4.57.3.tar.gz", hash = "sha256:df4945029aaddd7c09eec5cad851f30662f8bd1746721b34cc031d70c65afebc", size = 10139680, upload-time = "2025-11-25T15:51:30.139Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/97/7b/5621d08b34ac35deb9fa14b58d27d124d21ef125ee1c64bc724ca47dfb63/transformers-5.8.0-py3-none-any.whl", hash = "sha256:e9d2cae6d195a7e1e05164c5ebf26142a7044e4dc4267274f4809204f92827e4", size = 10630279, upload-time = "2026-05-05T16:50:01.026Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/6b/2f416568b3c4c91c96e5a365d164f8a4a4a88030aa8ab4644181fdadce97/transformers-4.57.3-py3-none-any.whl", hash = "sha256:c77d353a4851b1880191603d36acb313411d3577f6e2897814f333841f7003f4", size = 11993463, upload-time = "2025-11-25T15:51:26.493Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Problem

Running `deepreefmap reconstruct` with a segmentation model crashes when loading the coralscapes hub model:

```
ValueError: infer_schema(func): Parameter input has unsupported type torch.Tensor.
Got func with signature (input: 'torch.Tensor', weight: 'torch.Tensor', offs: 'torch.Tensor') -> 'torch.Tensor')
```

`transformers` 5.x registers a custom op (`transformers::grouped_mm_fallback`) using **string-typed** annotations in `torch.library.custom_op`. torch 2.4.1's `infer_schema` cannot parse string annotations, so simply importing `transformers` (via the hub model's `from transformers import AutoImageProcessor, AutoModel`) blows up.

torch is pinned to `==2.4.1` to keep CUDA 12.1 wheels for the workstation's NVIDIA 535 driver, so bumping torch is not an option here.

## Fix

- Pin `transformers==4.57.3` and `huggingface_hub>=0.34.0,<1.0` to stay compatible with torch 2.4.1.
- Add compatibility shims in `DinoV3DPTWrapper._lazy_load` for the older stack:
  - force `use_fast=True` on the `AutoImageProcessor`,
  - rename `encoder.model.*` → `encoder.*` state-dict keys when loading hub weights.

## Testing

Verified `deepreefmap reconstruct` now loads the `coralscapes-vit-b-dpt` model and proceeds through frame preparation without the `infer_schema` crash.