### PR TITLE
docs: add changelog, release workflow, and README cleanup

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,53 @@
+name: release
+
+# Pushing a vX.Y.Z tag builds the distributions and publishes a GitHub Release
+# whose notes are that version's CHANGELOG section.
+on:
+  push:
+    tags: ["v*"]
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          submodules: false
+
+      - name: Check the tag, pyproject.toml, and CHANGELOG.md agree
+        run: |
+          python - <<'PY'
+          import os, pathlib, re, sys, tomllib
+
+          version = os.environ["GITHUB_REF_NAME"].removeprefix("v")
+
+          packaged = tomllib.loads(pathlib.Path("pyproject.toml").read_text())["project"]["version"]
+          if packaged != version:
+              sys.exit(f"::error::tag is {version} but pyproject.toml says {packaged}")
+
+          changelog = pathlib.Path("CHANGELOG.md").read_text()
+          section = re.search(
+              rf"^## \[{re.escape(version)}\][^\n]*\n(.*?)(?=^## |\Z)",
+              changelog, re.MULTILINE | re.DOTALL,
+          )
+          if section is None or not section.group(1).strip():
+              sys.exit(f"::error::CHANGELOG.md has no content under '## [{version}]'")
+
+          pathlib.Path("release_notes.md").write_text(section.group(1).strip() + "\n")
+          PY
+
+      - uses: astral-sh/setup-uv@v7
+        with:
+          enable-cache: true
+          cache-dependency-glob: "uv.lock"
+
+      - name: Build
+        run: uv build
+
+      - name: Publish release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: gh release create "$GITHUB_REF_NAME" dist/* --title "$GITHUB_REF_NAME" --notes-file release_notes.md

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,73 @@
+# Changelog
+
+All notable changes to this project are documented in this file, following
+[Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and
+[Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+Changes that shift numeric outputs (benthic cover fractions, point counts, poses)
+are called out under **Changed** even when no flag or API changed, since they
+affect published measurements.
+
+## [Unreleased]
+
+## [1.1.0] - 2026-08-21
+
+### Added
+
+- Multi-vendor GPU support. `deepreefmap.device` resolves CUDA, ROCm, and Apple
+  Silicon (MPS) devices, picks an autocast dtype per backend, and falls back to
+  CPU for unsupported operations. (#25)
+- GPU-specific install extras, mutually exclusive: `cu126` (up to RTX 40-series),
+  `cu130` (RTX 50-series / Blackwell), and `rocm` (Linux). (#25)
+- Experimental AOTriton attention on ROCm so the LoGeR backend runs on RDNA3,
+  disabled with `TORCH_ROCM_AOTRITON_ENABLE_EXPERIMENTAL=0`. (#25)
+- Automatic segmentation checkpoint download from the Hugging Face Hub. Every
+  model in `list-models` resolves to a pinned `EPFL-ECEO/*` repository, so adding
+  a model is a table entry rather than new code. (#25)
+- Cancellable runs and progress reporting for library consumers: a
+  `ReconstructionCancelled` exception plus progress callbacks through ortho
+  aggregation and benthic cover computation, used by
+  [deepreefmap-gui](https://github.com/eceo-epfl/deepreefmap-gui). (#25)
+- User-writable LoGeR checkpoint directory via `platformdirs`
+  (`deepreefmap.paths.loger_ckpts_dir`), overridable with
+  `DEEPREEFMAP_LOGER_CKPTS`. (#25)
+- End-to-end reconstruction test. `tests/test_reconstruct_e2e.py` runs the full
+  `reconstruct` pipeline on a committed 7-second GoPro clip and diffs numeric
+  outputs against a golden file across 12 scenarios (SegFormer b2 and b5 × three
+  processing scales × 3 and 5 fps), one CI job each, publishing point clouds and
+  rendered viewpoints as artifacts. All weights are public, so fork pull requests
+  work unchanged. (#27)
+- `deepreefmap --version`.
+- `gopro_hero_12` camera profile (Hero 12, 4K Wide).
+
+### Changed
+
+- Requires torch >= 2.7 and transformers >= 5.8 (previously torch 2.4 and
+  transformers 4.x), plus huggingface_hub >= 1.14. (#25)
+- `deepreefmap.__version__` is read from installed package metadata instead of
+  being hard-coded, falling back to `0.0.0` in an uninstalled source tree. (#25)
+- Ortho products are also written as PNG for direct display. (#25)
+- README: removed three duplicated sections, fixed a Quickstart that pointed at a
+  video that was never committed and defaulted to a gated segmentation model, and
+  documented the `--replacement-radius-*`, `--refine-intrinsics-from-mapper`,
+  `--classes`, and LoGeR window flags.
+
+### Fixed
+
+- Point cloud construction is substantially faster and lower in peak memory —
+  packed voxel keys replace per-axis lexsorts, and LoGeR re-anchoring runs in
+  blocks instead of materializing a full float64 copy. Output is unchanged, with
+  tests asserting the clouds and their PLY bytes stay identical. (#31)
+- Point clouds are now deterministic when replacement or voxel keys tie.
+  Previously the tie-break could fall through to row order and leak thread
+  completion order into the cloud and its PLY. (#31)
+- LoGeR depth on the path where the backend returns no local points: the fallback
+  aliased the world points, which re-anchoring then rebased in place, so depth was
+  computed from rebased coordinates. (#31)
+
+## [1.0.0] - 2026-05-08
+
+Initial public release: semantic 3D reconstruction of coral reefs from handheld
+camera video, with SC-SfMLearner and LoGeR reconstruction backends, SegFormer and
+DINOv3-based segmentation, COLMAP-based camera calibration, ortho-mosaic and
+benthic cover reporting, and an interactive viser viewer.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -33,10 +33,61 @@ All model weights are public, so no Hugging Face credentials are required.
 
 Each CI job publishes its point cloud and rendered viewpoints as build artifacts.
 
+## Changelog
+
+If your change is user-facing, add a line to [CHANGELOG.md](CHANGELOG.md) under
+`## [Unreleased]`, in the right group (`Added`, `Changed`, `Deprecated`,
+`Removed`, `Fixed`, `Security`), ending with your pull request number:
+
+```markdown
+## [Unreleased]
+
+### Fixed
+
+- Point cloud construction is faster and lower in peak memory, with output
+  unchanged. (#31)
+```
+
+Write it for someone deciding whether to upgrade, not as a summary of your diff.
+
+Skip it for refactors, tests, CI, and routine dependency bumps.
+
+**Always add an entry if your change alters reconstruction results** — cover
+fractions, point counts, poses — and say which way they move. A shift invalidates
+measurements someone has already published, and a dependency bump alone can cause
+one. Don't rely on the e2e golden file to tell you: it only exercises
+`scsfmlearner` on CPU and compares within tolerances, so a LoGeR change or a
+sub-tolerance drift won't show up there.
+
+## Releasing
+
+Versions follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+Entries are already under `## [Unreleased]`, so a release is mostly renaming a
+heading. Read them through first — they become the public release notes.
+
+1. In `CHANGELOG.md`, rename `## [Unreleased]` to `## [1.2.0] - 2026-08-21` and
+   leave a fresh empty `## [Unreleased]` above it.
+2. Set `version = "1.2.0"` in `pyproject.toml`.
+3. Tag and push:
+
+   ```bash
+   git commit -am "chore(release): 1.2.0"
+   git tag v1.2.0
+   git push origin main v1.2.0
+   ```
+
+The tag triggers the `release` workflow, which builds the distributions and
+publishes a GitHub Release using that changelog section as the notes. If the tag
+and `pyproject.toml` disagree, or the changelog section is missing, it fails
+instead of publishing.
+
 ## Pull Request Checklist
 
 - Include or update focused tests for behavior changes.
 - Keep generated outputs, checkpoints, videos, and local editor files out of git.
 - Document any new model checkpoints, datasets, or third-party code with their
   source and license terms.
+- Add a `CHANGELOG.md` entry under `Unreleased` if the change is user-facing, and
+  always if it alters reconstruction results.
 - Run `uv run pytest` and `uv run ruff check deepreefmap tests` before review.

--- a/README.md
+++ b/README.md
@@ -1,9 +1,28 @@
 # DeepReefMap
 
-[DeepReefMap](https://besjournals.onlinelibrary.wiley.com/doi/full/10.1111/2041-210X.14307) is a software for rapid 3D semantic mapping of coral reefs from handheld cameras. 
+[![License: Apache 2.0](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](LICENSE)
+[![Python 3.10–3.12](https://img.shields.io/badge/python-3.10%20%7C%203.11%20%7C%203.12-blue.svg)](https://www.python.org/)
+[![DOI](https://img.shields.io/badge/DOI-10.1111%2F2041--210X.14307-blue.svg)](https://doi.org/10.1111/2041-210X.14307)
+
+[DeepReefMap](https://besjournals.onlinelibrary.wiley.com/doi/full/10.1111/2041-210X.14307) is a software for rapid 3D semantic mapping of coral reefs from handheld cameras.
 Repository maintained by [Hugues Sibille](https://github.com/HuguesSib) (EPFL) and [Jonathan Sauder](https://josauder.github.io/) (MIT/EPFL).
 
 ![DeepReefMap 3D viewer](assets/deepreefmap_view_3d_2x.gif)
+
+## Contents
+
+- [What you get](#what-you-get)
+- [Quickstart](#quickstart)
+- [How it works](#how-it-works)
+- [Desktop app](#desktop-app)
+- [Requirements](#requirements)
+- [Installation](#installation)
+- [Choosing models](#choosing-models)
+- [Camera setup and calibration](#camera-setup-and-calibration)
+- [Outputs](#outputs)
+- [Interactive viewer (viser)](#interactive-viewer-viser)
+- [CLI reference](#cli-reference)
+- [Citation](#citation)
 
 ## What you get
 
@@ -16,11 +35,11 @@ From one input video, a run produces:
 
 ## Quickstart
 
-Example input clip (10s GoPro Hero 10, Linear mode):
+Example input clip (GoPro Hero 10, Linear mode):
 
 ![Example input clip](assets/demo_input.gif)
 
-Get a first reconstruction running in three commands. This uses the lightest backend (`scsfmlearner`) and the bundled GoPro Hero 10 profile.
+Get a first reconstruction running in three commands, on the 7-second clip committed for the end-to-end test. This uses the lightest reconstruction backend (`scsfmlearner`), a SegFormer segmentation model, and the bundled GoPro Hero 10 profile — all weights are public, so no Hugging Face account is needed.
 
 ```bash
 # 1. Install
@@ -28,9 +47,10 @@ uv sync
 
 # 2. Run a reconstruction
 uv run deepreefmap reconstruct \
-  --videos assets/demo_input.mp4 \
+  --videos tests/data/reef_clip.mp4 \
   --camera-profile gopro_hero_10 \
   --mapping scsfmlearner \
+  --segmentation segformer-b2 \
   --out out \
   --viser
 
@@ -38,8 +58,11 @@ uv run deepreefmap reconstruct \
 uv run deepreefmap view-run --run-dir out --viser-port 8080
 ```
 
-Don't have a GoPro Hero 10? See [Camera setup](#camera-setup-and-calibration) to calibrate your own. 
-Want better quality? See the [LoGeR backend](#loger-higher-quality-more-setup).
+Then:
+
+- Higher segmentation quality? The default `coralscapes-vit-b-dpt` is better but gated — see [Using DINOv3 models](#using-dinov3-models-authentication).
+- Higher reconstruction quality? See the [LoGeR backend](#loger-path-higher-quality-more-setup).
+- Different camera? Only GoPro Hero 10 and 12 profiles ship with the package — see [Camera setup and calibration](#camera-setup-and-calibration) to calibrate your own.
 
 ## How it works
 
@@ -59,7 +82,7 @@ Everything below covers the library and CLI.
 ## Requirements
 
 - Python 3.10, 3.11, or 3.12
-- `[uv](https://docs.astral.sh/uv/)` for dependency management
+- [uv](https://docs.astral.sh/uv/) for dependency management
 - FFmpeg (pulled in via `imageio[ffmpeg]`)
 - **GPU**: strongly recommended. NVIDIA (CUDA), AMD (ROCm), and Apple Silicon (MPS) are supported. CPU-only runs work with `scsfmlearner` but are slow.
 
@@ -94,7 +117,17 @@ uv sync --extra gopro --extra train
 
 Extras can be combined (eg. `uv sync --extra rocm --extra gopro --extra loger`).
 
-### Choose a reconstruction backend
+| Extra | Purpose |
+| --- | --- |
+| `cu126`, `cu130`, `rocm` | GPU-specific torch builds (mutually exclusive) |
+| `loger` | Runtime dependencies for the LoGeR backend |
+| `gopro` | GoPro telemetry parsing (Linux x86-64 only) |
+| `train` | Training/logging tools (`wandb`, `tensorboard`) |
+| `dev` | `pytest`, `ruff`, `mypy` |
+
+## Choosing models
+
+### Reconstruction backend
 
 To run `deepreefmap reconstruct`, you need at least one reconstruction backend:
 
@@ -143,8 +176,14 @@ uv run deepreefmap reconstruct \
   --videos GX010001.MP4 \
   --mapping loger_star \
   --camera-profile gopro_hero_10 \
-  --out out_loger \
+  --out out_loger
 ```
+
+`DEEPREEFMAP_LOGER_CKPTS` overrides the LoGeR checkpoint directory, eg. to point at an existing `third_party/LoGeR/ckpts`.
+
+### Segmentation model
+
+Two families of segmentation models are available:
 
 - **DINOv3-based** (`coralscapes-vit-*-dpt`): higher quality, **requires Hugging Face authentication** (gated models).
 - **SegFormer**: lighter and faster, no authentication needed.
@@ -166,11 +205,22 @@ uv run huggingface-cli login
 
 ## Camera setup and calibration
 
-### GoPro Hero 10 in Linear mode with GoPro casing
+### Bundled profiles
 
-If your footage is from a GoPro Hero 10 in Linear mode with the GoPro casing setup used by this project, use the built-in profile:
+Two profiles ship with the package, under `deepreefmap/resources/camera_profiles/`. Both were calibrated with the built-in COLMAP calibrator (`RADIAL` model, 100 registered frames sampled at 10 fps).
 
-- Camera profile: `gopro_hero_10` (bundled JSON: `deepreefmap/resources/camera_profiles/gopro_hero_10.json`). You can also override or add profiles with `./camera_profiles/<name>.json` in the current working directory.
+| Profile | Camera and mode | Rectified size | Mean reprojection error |
+| --- | --- | --- | --- |
+| `gopro_hero_10` | Hero 10, Linear mode, GoPro casing | 1920×1080 | 0.78 px |
+| `gopro_hero_12` | Hero 12, 4K Wide | 3840×2160 | 1.31 px |
+
+List what is available in your install:
+
+```bash
+uv run deepreefmap list-profiles
+```
+
+You can also override a bundled profile or add your own by placing `./camera_profiles/<name>.json` in the current working directory.
 
 Example:
 
@@ -182,12 +232,6 @@ uv run deepreefmap reconstruct \
   --mapping scsfmlearner \
   --out out
 ```
-
-## Camera setup and calibration
-
-### Bundled profile: GoPro Hero 10 (Linear mode, GoPro casing)
-
-If your footage matches this setup, use `--camera-profile gopro_hero_10` (bundled at `deepreefmap/resources/camera_profiles/gopro_hero_10.json`). You can also drop your own profile at `./camera_profiles/<name>.json` in the working directory.
 
 ### Calibrating a different camera
 
@@ -224,7 +268,7 @@ uv run deepreefmap reconstruct \
 Each run writes:
 
 - `frames/`, `labels/`, `masks/` — rectified frames, semantic labels, keep masks.
-- `mapping_outputs.npz` — depth, poses, intrinsics, confidence, frame indices.
+- `mapping_outputs.npz` — depth, poses, intrinsics, confidence, frame indices, gravity vectors, world points, and scale type. These keys are what a resumed run reads back.
 - `semantic_reference_cloud.ply` — filtered semantic point cloud.
 - `tsdf_cloud.ply`, `semantic_tsdf_cloud.ply` — when `--tsdf` is enabled.
 - `ortho.png`, `ortho.npz` — aggregated ortho products.
@@ -250,53 +294,58 @@ In the viewer you can:
 ## CLI reference
 
 ```bash
-uv run deepreefmap list-models           # available segmentation + mapping models
-uv run deepreefmap list-profiles         # available camera profiles
-uv run deepreefmap reconstruct ...       # main pipeline
-uv run deepreefmap calibrate VIDEO ...   # camera calibration via COLMAP
+uv run deepreefmap --version              # installed version
+uv run deepreefmap list-models            # available segmentation + mapping models
+uv run deepreefmap list-profiles          # available camera profiles
+uv run deepreefmap reconstruct ...        # main pipeline
+uv run deepreefmap calibrate VIDEO ...    # camera calibration via COLMAP
 uv run deepreefmap verify-calibration NAME
 uv run deepreefmap render-video --run-dir out
 uv run deepreefmap view-run --run-dir out --viser-port 8080
 ```
 
-Useful `reconstruct` flags:
+Run `uv run deepreefmap reconstruct --help` for the full list. The flags you are most likely to reach for:
 
-- `--grid-bins`: ortho aggregation resolution.
-- `--keep-viser-open` / `--no-keep-viser-open`: keep viewer running after processing.
-- `--require-gravity-telemetry`: fail if gravity telemetry cannot be loaded/aligned.
-- `--preprocess-batch-size`: segmentation batch size during frame preparation.
-- `--transect-length` and `--transect-crop-width`: crop outputs around dominant transect.
-- `--skip-segmentation`: geometry-only run (no semantics).
+**Input and output**
 
-`DEEPREEFMAP_LOGER_CKPTS` overrides the LoGeR checkpoint directory, eg. an existing `third_party/LoGeR/ckpts`.
+- `--videos`: comma-separated video paths, in processing order (required).
+- `--camera-profile`: profile name (required). See [Camera setup](#camera-setup-and-calibration).
+- `--out`: output directory (default `out`).
+- `--fps`: target processing framerate (default `10`).
+- `--begin` / `--end`: trim the concatenated stream, in seconds.
+- `--classes`: classes YAML with class roles and colors (default `configs/classes_coralscapes.yaml`).
 
-## Reconstruction outputs
+**Models**
 
-Each run writes cached and derived artifacts:
+- `--segmentation`: segmentation model name (default `coralscapes-vit-b-dpt`).
+- `--mapping`: reconstruction backend (default `scsfmlearner`).
+- `--skip-segmentation`: geometry-only run, no semantics.
 
-- `frames/`, `labels/`, `masks/`: rectified frames, semantic labels, and keep masks.
-- `mapping_outputs.npz`: depth, poses, intrinsics, confidence, frame indices.
-- `semantic_reference_cloud.ply`: filtered semantic point cloud.
-- `tsdf_cloud.ply` and `semantic_tsdf_cloud.ply`: optional TSDF outputs when `--tsdf` is enabled.
-- `ortho.png` and `ortho.npz`: aggregated ortho products.
-- `benthic_cover.json`: class counts and cover fractions.
-- `geometry_cloud.ply`: geometry-only cloud from `--skip-segmentation`.
-- `run_manifest.json`: canonical run manifest (`semantic` or `geometry_only`).
+**Resolution and throughput**
 
-## Viser app (interactive viewer)
+- `--processing-width` / `--processing-height`: frame size before segmentation and mapping (default `1376×768`). The dominant quality/speed knob.
+- `--preprocess-batch-size`: frames segmented together during preparation (default `4`).
 
-You can use live viewing during reconstruction (`--viser`) or open an existing run:
+**Point cloud and ortho**
 
-```bash
-uv run deepreefmap view-run --run-dir out --viser-port 8080
-```
+- `--tsdf` / `--no-tsdf`: optional TSDF fusion output.
+- `--grid-bins`: ortho aggregation resolution (default `2000`).
+- `--replacement-radius-factor`: multiplier on the auto replacement radius (>1 coarser voxels and stronger thinning, <1 finer).
+- `--replacement-radius-override`: absolute replacement voxel size in meters, skipping the auto estimate.
+- `--replacement-radius-estimation-frames`: leading depth maps used for the auto estimate (default `30`).
+- `--transect-length` / `--transect-crop-width`: crop outputs around the dominant transect, in meters.
 
-Viewer highlights:
+**Backend-specific**
 
-- Click a camera frustum to jump timeline.
-- Inspect RGB, segmentation, and depth for each frame.
-- Toggle class visibility and switch color mode (RGB vs semantic colors).
-- Use `Accumulate` to overlay filtered points up to current timeline index.
+- `--loger-model-path`, `--loger-window-size` (default `32`), `--loger-overlap-size` (default `3`).
+- `--scsfmlearner-checkpoint-path`, `--scsfmlearner-width` (default `512`), `--scsfmlearner-height` (default `256`).
+- `--refine-intrinsics-from-mapper`: let the mapping backend refine intrinsics and override the camera profile's `K` downstream.
+
+**Telemetry and viewer**
+
+- `--require-gravity-telemetry`: fail the run if gravity telemetry cannot be loaded or aligned, instead of continuing unaligned.
+- `--viser` / `--viser-port`: live viewer during reconstruction.
+- `--keep-viser-open` / `--no-keep-viser-open`: keep the viewer running after outputs are generated (default: keep open).
 
 ## Citation
 
@@ -336,6 +385,10 @@ If you use the **LoGeR** backend (`--mapping loger` or `loger_star`), please als
   year={2026}
 }
 ```
+
+## Contributing
+
+See [CONTRIBUTING.md](CONTRIBUTING.md) for development setup, the test suite, and the pull request checklist. Notable changes are recorded in [CHANGELOG.md](CHANGELOG.md).
 
 ## Acknowledgements
 

--- a/deepreefmap/cli/main.py
+++ b/deepreefmap/cli/main.py
@@ -8,6 +8,28 @@ import typer
 app = typer.Typer(help="DeepReefMap command line interface")
 
 
+def _version_callback(value: bool) -> None:
+    if not value:
+        return
+    from deepreefmap import __version__
+
+    typer.echo(__version__)
+    raise typer.Exit()
+
+
+@app.callback()
+def main(
+    version: bool = typer.Option(
+        False,
+        "--version",
+        callback=_version_callback,
+        is_eager=True,
+        help="Show the installed DeepReefMap version and exit.",
+    ),
+) -> None:
+    """DeepReefMap command line interface"""
+
+
 def _available_profiles() -> list[str]:
     from deepreefmap.camera.intrinsics import available_profile_names
 

--- a/deepreefmap/resources/camera_profiles/gopro_hero_12.json
+++ b/deepreefmap/resources/camera_profiles/gopro_hero_12.json
@@ -1,0 +1,55 @@
+{
+  "name": "gopro_hero_12_4k_wide",
+  "source": "colmap_radial_v1",
+  "distorted": {
+    "model": "RADIAL",
+    "params": {
+      "fx": 2398.207330062544,
+      "fy": 2398.207330062544,
+      "cx": 1920.0,
+      "cy": 1080.0,
+      "k1": 0.3635862291164943,
+      "k2": 0.29770069330548476
+    }
+  },
+  "rectified_pinhole": {
+    "image_size": [
+      3840,
+      2160
+    ],
+    "K": [
+      [
+        3094.475830078125,
+        0.0,
+        1919.5
+      ],
+      [
+        0.0,
+        3094.475830078125,
+        1079.5
+      ],
+      [
+        0.0,
+        0.0,
+        1.0
+      ]
+    ]
+  },
+  "diagnostics": {
+    "n_input_frames": 100,
+    "n_registered_images": 100,
+    "mean_reprojection_error_px": 1.305746044435041,
+    "camera_model": "RADIAL",
+    "rectification_mode": "undistort",
+    "source_video": "GX010046.MP4",
+    "sampling_fps": 10,
+    "begin_s": null,
+    "end_s": null,
+    "valid_roi_xywh": [
+      0,
+      0,
+      3839,
+      2159
+    ]
+  }
+}


### PR DESCRIPTION
## Why

`pyproject.toml` said `1.1.0` while the newest tag was `v1.0.0`, with no changelog and no release automation. This adds the missing pieces and fixes docs that had drifted.

## What

**`CHANGELOG.md`** — [Keep a Changelog 1.1.0](https://keepachangelog.com/en/1.1.0/), seeded with `1.1.0` and a baseline `1.0.0`. Contributors add their own lines under `Unreleased`.

**`.github/workflows/release.yml`** — publishes a GitHub Release on a `vX.Y.Z` tag, using that version's changelog section as the notes. Refuses to publish unless the tag and `pyproject.toml` agree and the changelog section exists. Already exercised: it built and published v1.1.0.

**README fixes**

- Quickstart pointed at `assets/demo_input.mp4`, which was never committed, and defaulted to a gated segmentation model. Now uses the committed test clip and `segformer-b2` — verified end to end.
- Removed three duplicated sections (camera setup, outputs, viser viewer).
- Fixed a markdown link nested in a code span, a code block with a trailing backslash, a dangling anchor, and an orphaned section missing its heading.
- Documented the missing `--replacement-radius-*`, `--refine-intrinsics-from-mapper`, `--classes`, and LoGeR window flags, plus the full `mapping_outputs.npz` key set a resumed run reads back.

**Also** — `deepreefmap --version`, and the `gopro_hero_12` profile, which shipped in `list-profiles` but was untracked and undocumented.

## Verified

- Quickstart runs end to end, exit 0, producing every artifact the README lists
- 143 tests pass, 12 skipped; ruff clean; no new mypy errors
- All anchors and relative links resolve in all three docs
- `uv build` succeeds in a submodule-free worktree (matching CI checkout)

## Follow-up, not in this PR

The release wheel contains **zero `loger` files**, because the workflow checks out with `submodules: false`. `pyproject.toml` says LoGeR is vendored into the wheel; `THIRD_PARTY_NOTICES.md` says to keep it out of release archives while its license is unresolved. This PR implements the second reading by omission — worth making deliberate either way.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
